### PR TITLE
Remove author headers and anonymize

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # miniF2F - Dafny Formal Verification Benchmark
 
-This repository contains a Dafny version of the miniF2F benchmark consisting of mathematical problems from competitions (AIME, AMC, IMO) along with automated evaluation infrastructure. It is maintained by Mantas Bakšys and Stefan Zetzsche.
+This repository contains a Dafny version of the miniF2F benchmark consisting of mathematical problems from competitions (AIME, AMC, IMO) along with automated evaluation infrastructure.
 
 ## Overview
 

--- a/dataset/example_solutions/algebra.dfy
+++ b/dataset/example_solutions/algebra.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/example_solutions/cauchy_schwarz.dfy
+++ b/dataset/example_solutions/cauchy_schwarz.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/example_solutions/functional.dfy
+++ b/dataset/example_solutions/functional.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/example_solutions/human_written.dfy
+++ b/dataset/example_solutions/human_written.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/example_solutions/imo_empty.dfy
+++ b/dataset/example_solutions/imo_empty.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/example_solutions/induction.dfy
+++ b/dataset/example_solutions/induction.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/example_solutions/nt_black_magic.dfy
+++ b/dataset/example_solutions/nt_black_magic.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/example_solutions/number_theory.dfy
+++ b/dataset/example_solutions/number_theory.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/example_solutions/with_library_expansion.dfy
+++ b/dataset/example_solutions/with_library_expansion.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/example_solutions/without_library_expansion.dfy
+++ b/dataset/example_solutions/without_library_expansion.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1983_p1.dfy
+++ b/dataset/test/aime_1983_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1983_p2.dfy
+++ b/dataset/test/aime_1983_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1983_p3.dfy
+++ b/dataset/test/aime_1983_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1984_p1.dfy
+++ b/dataset/test/aime_1984_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1984_p7.dfy
+++ b/dataset/test/aime_1984_p7.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1987_p5.dfy
+++ b/dataset/test/aime_1987_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1988_p8.dfy
+++ b/dataset/test/aime_1988_p8.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1989_p8.dfy
+++ b/dataset/test/aime_1989_p8.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1990_p15.dfy
+++ b/dataset/test/aime_1990_p15.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1990_p4.dfy
+++ b/dataset/test/aime_1990_p4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1991_p9.dfy
+++ b/dataset/test/aime_1991_p9.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1994_p3.dfy
+++ b/dataset/test/aime_1994_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1995_p7.dfy
+++ b/dataset/test/aime_1995_p7.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1997_p9.dfy
+++ b/dataset/test/aime_1997_p9.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/aime_1999_p11.dfy
+++ b/dataset/test/aime_1999_p11.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_2varlineareq_fp3zeq11_3tfm1m5zeqn68_feqn10_zeq7.dfy
+++ b/dataset/test/algebra_2varlineareq_fp3zeq11_3tfm1m5zeqn68_feqn10_zeq7.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_9onxpypzleqsum2onxpy.dfy
+++ b/dataset/test/algebra_9onxpypzleqsum2onxpy.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_abpbcpcageq3_sumaonsqrtapbgeq3onsqrt2.dfy
+++ b/dataset/test/algebra_abpbcpcageq3_sumaonsqrtapbgeq3onsqrt2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_absapbon1pabsapbleqsumabsaon1pabsa.dfy
+++ b/dataset/test/algebra_absapbon1pabsapbleqsumabsaon1pabsa.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_absxm1pabsxpabsxp1eqxp2_0leqxleq1.dfy
+++ b/dataset/test/algebra_absxm1pabsxpabsxp1eqxp2_0leqxleq1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_amgm_sum1toneqn_prod1tonleq1.dfy
+++ b/dataset/test/algebra_amgm_sum1toneqn_prod1tonleq1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_amgm_sumasqdivbgeqsuma.dfy
+++ b/dataset/test/algebra_amgm_sumasqdivbgeqsuma.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_apbmpcneq0_aeq0anbeq0anceq0.dfy
+++ b/dataset/test/algebra_apbmpcneq0_aeq0anbeq0anceq0.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_apbon2pownleqapownpbpowon2.dfy
+++ b/dataset/test/algebra_apbon2pownleqapownpbpowon2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_apbpceq2_abpbcpcaeq1_aleq1on3anbleq1ancleq4on3.dfy
+++ b/dataset/test/algebra_apbpceq2_abpbcpcaeq1_aleq1on3anbleq1ancleq4on3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_bleqa_apbon2msqrtableqambsqon8b.dfy
+++ b/dataset/test/algebra_bleqa_apbon2msqrtableqambsqon8b.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_cubrtrp1oncubrtreq3_rcubp1onrcubeq5778.dfy
+++ b/dataset/test/algebra_cubrtrp1oncubrtreq3_rcubp1onrcubeq5778.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_ineq_nto1onlt2m1on.dfy
+++ b/dataset/test/algebra_ineq_nto1onlt2m1on.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_others_exirrpowirrrat.dfy
+++ b/dataset/test/algebra_others_exirrpowirrrat.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_sqineq_at2malt1.dfy
+++ b/dataset/test/algebra_sqineq_at2malt1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_sqineq_unitcircatbpabsamblt1.dfy
+++ b/dataset/test/algebra_sqineq_unitcircatbpabsamblt1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_sqineq_unitcircatbpamblt1.dfy
+++ b/dataset/test/algebra_sqineq_unitcircatbpamblt1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/algebra_sum1onsqrt2to1onsqrt10000lt198.dfy
+++ b/dataset/test/algebra_sum1onsqrt2to1onsqrt10000lt198.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12_2000_p1.dfy
+++ b/dataset/test/amc12_2000_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12_2000_p12.dfy
+++ b/dataset/test/amc12_2000_p12.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12_2000_p20.dfy
+++ b/dataset/test/amc12_2000_p20.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12_2000_p6.dfy
+++ b/dataset/test/amc12_2000_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12_2001_p21.dfy
+++ b/dataset/test/amc12_2001_p21.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12_2001_p5.dfy
+++ b/dataset/test/amc12_2001_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2002_p13.dfy
+++ b/dataset/test/amc12a_2002_p13.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2002_p6.dfy
+++ b/dataset/test/amc12a_2002_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2003_p23.dfy
+++ b/dataset/test/amc12a_2003_p23.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2003_p5.dfy
+++ b/dataset/test/amc12a_2003_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2008_p25.dfy
+++ b/dataset/test/amc12a_2008_p25.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2009_p6.dfy
+++ b/dataset/test/amc12a_2009_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2009_p7.dfy
+++ b/dataset/test/amc12a_2009_p7.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2013_p4.dfy
+++ b/dataset/test/amc12a_2013_p4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2019_p12.dfy
+++ b/dataset/test/amc12a_2019_p12.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2020_p10.dfy
+++ b/dataset/test/amc12a_2020_p10.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2020_p15.dfy
+++ b/dataset/test/amc12a_2020_p15.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2020_p25.dfy
+++ b/dataset/test/amc12a_2020_p25.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2020_p4.dfy
+++ b/dataset/test/amc12a_2020_p4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2020_p7.dfy
+++ b/dataset/test/amc12a_2020_p7.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2020_p9.dfy
+++ b/dataset/test/amc12a_2020_p9.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2021_p12.dfy
+++ b/dataset/test/amc12a_2021_p12.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2021_p14.dfy
+++ b/dataset/test/amc12a_2021_p14.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2021_p18.dfy
+++ b/dataset/test/amc12a_2021_p18.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2021_p19.dfy
+++ b/dataset/test/amc12a_2021_p19.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2021_p22.dfy
+++ b/dataset/test/amc12a_2021_p22.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2021_p25.dfy
+++ b/dataset/test/amc12a_2021_p25.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2021_p3.dfy
+++ b/dataset/test/amc12a_2021_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2021_p8.dfy
+++ b/dataset/test/amc12a_2021_p8.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12a_2021_p9.dfy
+++ b/dataset/test/amc12a_2021_p9.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2002_p19.dfy
+++ b/dataset/test/amc12b_2002_p19.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2002_p2.dfy
+++ b/dataset/test/amc12b_2002_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2002_p4.dfy
+++ b/dataset/test/amc12b_2002_p4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2002_p7.dfy
+++ b/dataset/test/amc12b_2002_p7.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2020_p13.dfy
+++ b/dataset/test/amc12b_2020_p13.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2020_p2.dfy
+++ b/dataset/test/amc12b_2020_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2020_p21.dfy
+++ b/dataset/test/amc12b_2020_p21.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2020_p22.dfy
+++ b/dataset/test/amc12b_2020_p22.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2020_p6.dfy
+++ b/dataset/test/amc12b_2020_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2021_p1.dfy
+++ b/dataset/test/amc12b_2021_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2021_p13.dfy
+++ b/dataset/test/amc12b_2021_p13.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2021_p18.dfy
+++ b/dataset/test/amc12b_2021_p18.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2021_p3.dfy
+++ b/dataset/test/amc12b_2021_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2021_p4.dfy
+++ b/dataset/test/amc12b_2021_p4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/amc12b_2021_p9.dfy
+++ b/dataset/test/amc12b_2021_p9.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1959_p1.dfy
+++ b/dataset/test/imo_1959_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1960_p2.dfy
+++ b/dataset/test/imo_1960_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1962_p2.dfy
+++ b/dataset/test/imo_1962_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1963_p5.dfy
+++ b/dataset/test/imo_1963_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1964_p2.dfy
+++ b/dataset/test/imo_1964_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1965_p2.dfy
+++ b/dataset/test/imo_1965_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1968_p5_1.dfy
+++ b/dataset/test/imo_1968_p5_1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1969_p2.dfy
+++ b/dataset/test/imo_1969_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1974_p3.dfy
+++ b/dataset/test/imo_1974_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1977_p6.dfy
+++ b/dataset/test/imo_1977_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1981_p6.dfy
+++ b/dataset/test/imo_1981_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1982_p1.dfy
+++ b/dataset/test/imo_1982_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1983_p6.dfy
+++ b/dataset/test/imo_1983_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1984_p6.dfy
+++ b/dataset/test/imo_1984_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1985_p6.dfy
+++ b/dataset/test/imo_1985_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1992_p1.dfy
+++ b/dataset/test/imo_1992_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_1997_p5.dfy
+++ b/dataset/test/imo_1997_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_2001_p6.dfy
+++ b/dataset/test/imo_2001_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_2007_p6.dfy
+++ b/dataset/test/imo_2007_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/imo_2019_p1.dfy
+++ b/dataset/test/imo_2019_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/induction_11div10tonmn1ton.dfy
+++ b/dataset/test/induction_11div10tonmn1ton.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/induction_12dvd4expnp1p20.dfy
+++ b/dataset/test/induction_12dvd4expnp1p20.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/induction_1pxpownlt1pnx.dfy
+++ b/dataset/test/induction_1pxpownlt1pnx.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/induction_nfactltnexpnm1ngt3.dfy
+++ b/dataset/test/induction_nfactltnexpnm1ngt3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/induction_pord1p1on2powklt5on2.dfy
+++ b/dataset/test/induction_pord1p1on2powklt5on2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/induction_pprime_pdvdapowpma.dfy
+++ b/dataset/test/induction_pprime_pdvdapowpma.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/induction_prod1p1onk3le3m1onn.dfy
+++ b/dataset/test/induction_prod1p1onk3le3m1onn.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/induction_sumkexp3eqsumksq.dfy
+++ b/dataset/test/induction_sumkexp3eqsumksq.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_107.dfy
+++ b/dataset/test/mathd_algebra_107.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_113.dfy
+++ b/dataset/test/mathd_algebra_113.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_114.dfy
+++ b/dataset/test/mathd_algebra_114.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_125.dfy
+++ b/dataset/test/mathd_algebra_125.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_129.dfy
+++ b/dataset/test/mathd_algebra_129.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_137.dfy
+++ b/dataset/test/mathd_algebra_137.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_139.dfy
+++ b/dataset/test/mathd_algebra_139.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_141.dfy
+++ b/dataset/test/mathd_algebra_141.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_142.dfy
+++ b/dataset/test/mathd_algebra_142.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_143.dfy
+++ b/dataset/test/mathd_algebra_143.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_148.dfy
+++ b/dataset/test/mathd_algebra_148.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_153.dfy
+++ b/dataset/test/mathd_algebra_153.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_156.dfy
+++ b/dataset/test/mathd_algebra_156.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_158.dfy
+++ b/dataset/test/mathd_algebra_158.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_160.dfy
+++ b/dataset/test/mathd_algebra_160.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_17.dfy
+++ b/dataset/test/mathd_algebra_17.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_170.dfy
+++ b/dataset/test/mathd_algebra_170.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_171.dfy
+++ b/dataset/test/mathd_algebra_171.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_176.dfy
+++ b/dataset/test/mathd_algebra_176.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_184.dfy
+++ b/dataset/test/mathd_algebra_184.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_188.dfy
+++ b/dataset/test/mathd_algebra_188.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_196.dfy
+++ b/dataset/test/mathd_algebra_196.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_208.dfy
+++ b/dataset/test/mathd_algebra_208.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_209.dfy
+++ b/dataset/test/mathd_algebra_209.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_215.dfy
+++ b/dataset/test/mathd_algebra_215.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_24.dfy
+++ b/dataset/test/mathd_algebra_24.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_246.dfy
+++ b/dataset/test/mathd_algebra_246.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_263.dfy
+++ b/dataset/test/mathd_algebra_263.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_270.dfy
+++ b/dataset/test/mathd_algebra_270.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_275.dfy
+++ b/dataset/test/mathd_algebra_275.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_276.dfy
+++ b/dataset/test/mathd_algebra_276.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_288.dfy
+++ b/dataset/test/mathd_algebra_288.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_289.dfy
+++ b/dataset/test/mathd_algebra_289.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_293.dfy
+++ b/dataset/test/mathd_algebra_293.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_296.dfy
+++ b/dataset/test/mathd_algebra_296.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_302.dfy
+++ b/dataset/test/mathd_algebra_302.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_304.dfy
+++ b/dataset/test/mathd_algebra_304.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_313.dfy
+++ b/dataset/test/mathd_algebra_313.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_314.dfy
+++ b/dataset/test/mathd_algebra_314.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_320.dfy
+++ b/dataset/test/mathd_algebra_320.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_329.dfy
+++ b/dataset/test/mathd_algebra_329.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_33.dfy
+++ b/dataset/test/mathd_algebra_33.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_332.dfy
+++ b/dataset/test/mathd_algebra_332.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_338.dfy
+++ b/dataset/test/mathd_algebra_338.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_342.dfy
+++ b/dataset/test/mathd_algebra_342.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_346.dfy
+++ b/dataset/test/mathd_algebra_346.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_354.dfy
+++ b/dataset/test/mathd_algebra_354.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_359.dfy
+++ b/dataset/test/mathd_algebra_359.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_362.dfy
+++ b/dataset/test/mathd_algebra_362.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_388.dfy
+++ b/dataset/test/mathd_algebra_388.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_392.dfy
+++ b/dataset/test/mathd_algebra_392.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_398.dfy
+++ b/dataset/test/mathd_algebra_398.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_400.dfy
+++ b/dataset/test/mathd_algebra_400.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_412.dfy
+++ b/dataset/test/mathd_algebra_412.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_419.dfy
+++ b/dataset/test/mathd_algebra_419.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_427.dfy
+++ b/dataset/test/mathd_algebra_427.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_432.dfy
+++ b/dataset/test/mathd_algebra_432.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_44.dfy
+++ b/dataset/test/mathd_algebra_44.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_440.dfy
+++ b/dataset/test/mathd_algebra_440.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_441.dfy
+++ b/dataset/test/mathd_algebra_441.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_452.dfy
+++ b/dataset/test/mathd_algebra_452.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_459.dfy
+++ b/dataset/test/mathd_algebra_459.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_478.dfy
+++ b/dataset/test/mathd_algebra_478.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_484.dfy
+++ b/dataset/test/mathd_algebra_484.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_487.dfy
+++ b/dataset/test/mathd_algebra_487.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_513.dfy
+++ b/dataset/test/mathd_algebra_513.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_598.dfy
+++ b/dataset/test/mathd_algebra_598.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_756.dfy
+++ b/dataset/test/mathd_algebra_756.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_76.dfy
+++ b/dataset/test/mathd_algebra_76.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_algebra_80.dfy
+++ b/dataset/test/mathd_algebra_80.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_100.dfy
+++ b/dataset/test/mathd_numbertheory_100.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_1124.dfy
+++ b/dataset/test/mathd_numbertheory_1124.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_12.dfy
+++ b/dataset/test/mathd_numbertheory_12.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_127.dfy
+++ b/dataset/test/mathd_numbertheory_127.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_135.dfy
+++ b/dataset/test/mathd_numbertheory_135.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_150.dfy
+++ b/dataset/test/mathd_numbertheory_150.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_175.dfy
+++ b/dataset/test/mathd_numbertheory_175.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_185.dfy
+++ b/dataset/test/mathd_numbertheory_185.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_207.dfy
+++ b/dataset/test/mathd_numbertheory_207.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_212.dfy
+++ b/dataset/test/mathd_numbertheory_212.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_222.dfy
+++ b/dataset/test/mathd_numbertheory_222.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_227.dfy
+++ b/dataset/test/mathd_numbertheory_227.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_229.dfy
+++ b/dataset/test/mathd_numbertheory_229.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_233.dfy
+++ b/dataset/test/mathd_numbertheory_233.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_234.dfy
+++ b/dataset/test/mathd_numbertheory_234.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_235.dfy
+++ b/dataset/test/mathd_numbertheory_235.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_237.dfy
+++ b/dataset/test/mathd_numbertheory_237.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_239.dfy
+++ b/dataset/test/mathd_numbertheory_239.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_247.dfy
+++ b/dataset/test/mathd_numbertheory_247.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_254.dfy
+++ b/dataset/test/mathd_numbertheory_254.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_277.dfy
+++ b/dataset/test/mathd_numbertheory_277.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_293.dfy
+++ b/dataset/test/mathd_numbertheory_293.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_296.dfy
+++ b/dataset/test/mathd_numbertheory_296.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_299.dfy
+++ b/dataset/test/mathd_numbertheory_299.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_3.dfy
+++ b/dataset/test/mathd_numbertheory_3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_314.dfy
+++ b/dataset/test/mathd_numbertheory_314.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_320.dfy
+++ b/dataset/test/mathd_numbertheory_320.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_321.dfy
+++ b/dataset/test/mathd_numbertheory_321.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_328.dfy
+++ b/dataset/test/mathd_numbertheory_328.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_34.dfy
+++ b/dataset/test/mathd_numbertheory_34.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_341.dfy
+++ b/dataset/test/mathd_numbertheory_341.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_342.dfy
+++ b/dataset/test/mathd_numbertheory_342.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_343.dfy
+++ b/dataset/test/mathd_numbertheory_343.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_345.dfy
+++ b/dataset/test/mathd_numbertheory_345.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_353.dfy
+++ b/dataset/test/mathd_numbertheory_353.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_427.dfy
+++ b/dataset/test/mathd_numbertheory_427.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_430.dfy
+++ b/dataset/test/mathd_numbertheory_430.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_435.dfy
+++ b/dataset/test/mathd_numbertheory_435.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_447.dfy
+++ b/dataset/test/mathd_numbertheory_447.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_451.dfy
+++ b/dataset/test/mathd_numbertheory_451.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_457.dfy
+++ b/dataset/test/mathd_numbertheory_457.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_483.dfy
+++ b/dataset/test/mathd_numbertheory_483.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_495.dfy
+++ b/dataset/test/mathd_numbertheory_495.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_5.dfy
+++ b/dataset/test/mathd_numbertheory_5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_517.dfy
+++ b/dataset/test/mathd_numbertheory_517.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_521.dfy
+++ b/dataset/test/mathd_numbertheory_521.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_541.dfy
+++ b/dataset/test/mathd_numbertheory_541.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_551.dfy
+++ b/dataset/test/mathd_numbertheory_551.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_552.dfy
+++ b/dataset/test/mathd_numbertheory_552.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_559.dfy
+++ b/dataset/test/mathd_numbertheory_559.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_582.dfy
+++ b/dataset/test/mathd_numbertheory_582.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_618.dfy
+++ b/dataset/test/mathd_numbertheory_618.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_66.dfy
+++ b/dataset/test/mathd_numbertheory_66.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_711.dfy
+++ b/dataset/test/mathd_numbertheory_711.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_728.dfy
+++ b/dataset/test/mathd_numbertheory_728.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_764.dfy
+++ b/dataset/test/mathd_numbertheory_764.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_765.dfy
+++ b/dataset/test/mathd_numbertheory_765.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_769.dfy
+++ b/dataset/test/mathd_numbertheory_769.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_85.dfy
+++ b/dataset/test/mathd_numbertheory_85.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/mathd_numbertheory_99.dfy
+++ b/dataset/test/mathd_numbertheory_99.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/numbertheory_2pownm1prime_nprime.dfy
+++ b/dataset/test/numbertheory_2pownm1prime_nprime.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/numbertheory_3pow2pownm1mod2pownp3eq2pownp2.dfy
+++ b/dataset/test/numbertheory_3pow2pownm1mod2pownp3eq2pownp2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/numbertheory_4x3m7y3neq2003.dfy
+++ b/dataset/test/numbertheory_4x3m7y3neq2003.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/numbertheory_aoddbdiv4asqpbsqmod8eq1.dfy
+++ b/dataset/test/numbertheory_aoddbdiv4asqpbsqmod8eq1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/numbertheory_exk2powkeqapb2mulbpa2_aeq1.dfy
+++ b/dataset/test/numbertheory_exk2powkeqapb2mulbpa2_aeq1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/numbertheory_fxeq4powxp6powxp9powx_f2powmdvdf2pown.dfy
+++ b/dataset/test/numbertheory_fxeq4powxp6powxp9powx_f2powmdvdf2pown.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/numbertheory_notequiv2i2jasqbsqdiv8.dfy
+++ b/dataset/test/numbertheory_notequiv2i2jasqbsqdiv8.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/test/numbertheory_x5neqy2p4.dfy
+++ b/dataset/test/numbertheory_x5neqy2p4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aimeII_2001_p3.dfy
+++ b/dataset/valid/aimeII_2001_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aimeII_2020_p6.dfy
+++ b/dataset/valid/aimeII_2020_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aimeI_2000_p7.dfy
+++ b/dataset/valid/aimeI_2000_p7.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aime_1983_p9.dfy
+++ b/dataset/valid/aime_1983_p9.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aime_1984_p15.dfy
+++ b/dataset/valid/aime_1984_p15.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aime_1984_p5.dfy
+++ b/dataset/valid/aime_1984_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aime_1987_p8.dfy
+++ b/dataset/valid/aime_1987_p8.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aime_1988_p3.dfy
+++ b/dataset/valid/aime_1988_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aime_1988_p4.dfy
+++ b/dataset/valid/aime_1988_p4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aime_1990_p2.dfy
+++ b/dataset/valid/aime_1990_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aime_1991_p1.dfy
+++ b/dataset/valid/aime_1991_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aime_1991_p6.dfy
+++ b/dataset/valid/aime_1991_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aime_1994_p4.dfy
+++ b/dataset/valid/aime_1994_p4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aime_1996_p5.dfy
+++ b/dataset/valid/aime_1996_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/aime_1997_p12.dfy
+++ b/dataset/valid/aime_1997_p12.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_2complexrootspoly_xsqp49eqxp7itxpn7i.dfy
+++ b/dataset/valid/algebra_2complexrootspoly_xsqp49eqxp7itxpn7i.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_2rootsintpoly_am10tap11eqasqpam110.dfy
+++ b/dataset/valid/algebra_2rootsintpoly_am10tap11eqasqpam110.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_2rootspoly_apatapbeq2asqp2ab.dfy
+++ b/dataset/valid/algebra_2rootspoly_apatapbeq2asqp2ab.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_2varlineareq_xpeeq7_2xpeeq3_eeq11_xeqn4.dfy
+++ b/dataset/valid/algebra_2varlineareq_xpeeq7_2xpeeq3_eeq11_xeqn4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_3rootspoly_amdtamctambeqnasqmbpctapcbtdpasqmbpctapcbta.dfy
+++ b/dataset/valid/algebra_3rootspoly_amdtamctambeqnasqmbpctapcbtdpasqmbpctapcbta.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_amgm_faxinrrp2msqrt2geq2mxm1div2x.dfy
+++ b/dataset/valid/algebra_amgm_faxinrrp2msqrt2geq2mxm1div2x.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_amgm_prod1toneq1_sum1tongeqn.dfy
+++ b/dataset/valid/algebra_amgm_prod1toneq1_sum1tongeqn.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_amgm_sqrtxymulxmyeqxpy_xpygeq4.dfy
+++ b/dataset/valid/algebra_amgm_sqrtxymulxmyeqxpy_xpygeq4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_amgm_sumasqdivbsqgeqsumbdiva.dfy
+++ b/dataset/valid/algebra_amgm_sumasqdivbsqgeqsumbdiva.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_apb4leq8ta4pb4.dfy
+++ b/dataset/valid/algebra_apb4leq8ta4pb4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_binomnegdiscrineq_10alt28asqp1.dfy
+++ b/dataset/valid/algebra_binomnegdiscrineq_10alt28asqp1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_manipexpr_2erprsqpesqeqnrpnesq.dfy
+++ b/dataset/valid/algebra_manipexpr_2erprsqpesqeqnrpnesq.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_manipexpr_apbeq2cceqiacpbceqm2.dfy
+++ b/dataset/valid/algebra_manipexpr_apbeq2cceqiacpbceqm2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_sqineq_2at2pclta2c2p41pc.dfy
+++ b/dataset/valid/algebra_sqineq_2at2pclta2c2p41pc.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_sqineq_2unitcircatblt1.dfy
+++ b/dataset/valid/algebra_sqineq_2unitcircatblt1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_sqineq_36azm9asqle36zsq.dfy
+++ b/dataset/valid/algebra_sqineq_36azm9asqle36zsq.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_sqineq_4bap1lt4bsqpap1sq.dfy
+++ b/dataset/valid/algebra_sqineq_4bap1lt4bsqpap1sq.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/algebra_xmysqpymzsqpzmxsqeqxyz_xpypzp6dvdx3y3z3.dfy
+++ b/dataset/valid/algebra_xmysqpymzsqpzmxsqeqxyz_xpypzp6dvdx3y3z3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12_2000_p11.dfy
+++ b/dataset/valid/amc12_2000_p11.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12_2000_p15.dfy
+++ b/dataset/valid/amc12_2000_p15.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12_2000_p5.dfy
+++ b/dataset/valid/amc12_2000_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12_2001_p2.dfy
+++ b/dataset/valid/amc12_2001_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12_2001_p9.dfy
+++ b/dataset/valid/amc12_2001_p9.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2002_p1.dfy
+++ b/dataset/valid/amc12a_2002_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2002_p12.dfy
+++ b/dataset/valid/amc12a_2002_p12.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2002_p21.dfy
+++ b/dataset/valid/amc12a_2002_p21.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2003_p1.dfy
+++ b/dataset/valid/amc12a_2003_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2003_p24.dfy
+++ b/dataset/valid/amc12a_2003_p24.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2003_p25.dfy
+++ b/dataset/valid/amc12a_2003_p25.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2008_p15.dfy
+++ b/dataset/valid/amc12a_2008_p15.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2008_p2.dfy
+++ b/dataset/valid/amc12a_2008_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2008_p4.dfy
+++ b/dataset/valid/amc12a_2008_p4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2008_p8.dfy
+++ b/dataset/valid/amc12a_2008_p8.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2009_p15.dfy
+++ b/dataset/valid/amc12a_2009_p15.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2009_p2.dfy
+++ b/dataset/valid/amc12a_2009_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2009_p25.dfy
+++ b/dataset/valid/amc12a_2009_p25.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2009_p5.dfy
+++ b/dataset/valid/amc12a_2009_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2009_p9.dfy
+++ b/dataset/valid/amc12a_2009_p9.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2010_p10.dfy
+++ b/dataset/valid/amc12a_2010_p10.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2010_p11.dfy
+++ b/dataset/valid/amc12a_2010_p11.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2010_p22.dfy
+++ b/dataset/valid/amc12a_2010_p22.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2011_p18.dfy
+++ b/dataset/valid/amc12a_2011_p18.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2013_p7.dfy
+++ b/dataset/valid/amc12a_2013_p7.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2013_p8.dfy
+++ b/dataset/valid/amc12a_2013_p8.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2015_p10.dfy
+++ b/dataset/valid/amc12a_2015_p10.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2016_p2.dfy
+++ b/dataset/valid/amc12a_2016_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2016_p3.dfy
+++ b/dataset/valid/amc12a_2016_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2017_p2.dfy
+++ b/dataset/valid/amc12a_2017_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2017_p7.dfy
+++ b/dataset/valid/amc12a_2017_p7.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2019_p21.dfy
+++ b/dataset/valid/amc12a_2019_p21.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2019_p9.dfy
+++ b/dataset/valid/amc12a_2019_p9.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2020_p13.dfy
+++ b/dataset/valid/amc12a_2020_p13.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2020_p22.dfy
+++ b/dataset/valid/amc12a_2020_p22.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12a_2021_p7.dfy
+++ b/dataset/valid/amc12a_2021_p7.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12b_2002_p11.dfy
+++ b/dataset/valid/amc12b_2002_p11.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12b_2002_p3.dfy
+++ b/dataset/valid/amc12b_2002_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12b_2002_p6.dfy
+++ b/dataset/valid/amc12b_2002_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12b_2003_p17.dfy
+++ b/dataset/valid/amc12b_2003_p17.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12b_2003_p6.dfy
+++ b/dataset/valid/amc12b_2003_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12b_2003_p9.dfy
+++ b/dataset/valid/amc12b_2003_p9.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12b_2004_p3.dfy
+++ b/dataset/valid/amc12b_2004_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12b_2020_p5.dfy
+++ b/dataset/valid/amc12b_2020_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/amc12b_2021_p21.dfy
+++ b/dataset/valid/amc12b_2021_p21.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1961_p1.dfy
+++ b/dataset/valid/imo_1961_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1962_p4.dfy
+++ b/dataset/valid/imo_1962_p4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1964_p1_1.dfy
+++ b/dataset/valid/imo_1964_p1_1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1964_p1_2.dfy
+++ b/dataset/valid/imo_1964_p1_2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1965_p1.dfy
+++ b/dataset/valid/imo_1965_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1966_p4.dfy
+++ b/dataset/valid/imo_1966_p4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1966_p5.dfy
+++ b/dataset/valid/imo_1966_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1967_p3.dfy
+++ b/dataset/valid/imo_1967_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1973_p3.dfy
+++ b/dataset/valid/imo_1973_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1974_p5.dfy
+++ b/dataset/valid/imo_1974_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1977_p5.dfy
+++ b/dataset/valid/imo_1977_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1978_p5.dfy
+++ b/dataset/valid/imo_1978_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1979_p1.dfy
+++ b/dataset/valid/imo_1979_p1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1984_p2.dfy
+++ b/dataset/valid/imo_1984_p2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1987_p4.dfy
+++ b/dataset/valid/imo_1987_p4.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1987_p6.dfy
+++ b/dataset/valid/imo_1987_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1988_p6.dfy
+++ b/dataset/valid/imo_1988_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1990_p3.dfy
+++ b/dataset/valid/imo_1990_p3.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_1993_p5.dfy
+++ b/dataset/valid/imo_1993_p5.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/imo_2006_p6.dfy
+++ b/dataset/valid/imo_2006_p6.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/induction_divisibility_3div2tooddnp1.dfy
+++ b/dataset/valid/induction_divisibility_3div2tooddnp1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/induction_divisibility_3divnto3m2n.dfy
+++ b/dataset/valid/induction_divisibility_3divnto3m2n.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/induction_divisibility_9div10tonm1.dfy
+++ b/dataset/valid/induction_divisibility_9div10tonm1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/induction_ineq_nsqlefactn.dfy
+++ b/dataset/valid/induction_ineq_nsqlefactn.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/induction_seq_mul2pnp1.dfy
+++ b/dataset/valid/induction_seq_mul2pnp1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/induction_sum2kp1npqsqm1.dfy
+++ b/dataset/valid/induction_sum2kp1npqsqm1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/induction_sum_1oktkp1.dfy
+++ b/dataset/valid/induction_sum_1oktkp1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/induction_sum_odd.dfy
+++ b/dataset/valid/induction_sum_odd.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_10.dfy
+++ b/dataset/valid/mathd_algebra_10.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_101.dfy
+++ b/dataset/valid/mathd_algebra_101.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_104.dfy
+++ b/dataset/valid/mathd_algebra_104.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_109.dfy
+++ b/dataset/valid/mathd_algebra_109.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_11.dfy
+++ b/dataset/valid/mathd_algebra_11.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_110.dfy
+++ b/dataset/valid/mathd_algebra_110.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_116.dfy
+++ b/dataset/valid/mathd_algebra_116.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_119.dfy
+++ b/dataset/valid/mathd_algebra_119.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_123.dfy
+++ b/dataset/valid/mathd_algebra_123.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_126.dfy
+++ b/dataset/valid/mathd_algebra_126.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_13.dfy
+++ b/dataset/valid/mathd_algebra_13.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_131.dfy
+++ b/dataset/valid/mathd_algebra_131.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_132.dfy
+++ b/dataset/valid/mathd_algebra_132.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_140.dfy
+++ b/dataset/valid/mathd_algebra_140.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_144.dfy
+++ b/dataset/valid/mathd_algebra_144.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_149.dfy
+++ b/dataset/valid/mathd_algebra_149.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_15.dfy
+++ b/dataset/valid/mathd_algebra_15.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_151.dfy
+++ b/dataset/valid/mathd_algebra_151.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_159.dfy
+++ b/dataset/valid/mathd_algebra_159.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_181.dfy
+++ b/dataset/valid/mathd_algebra_181.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_182.dfy
+++ b/dataset/valid/mathd_algebra_182.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_185.dfy
+++ b/dataset/valid/mathd_algebra_185.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_190.dfy
+++ b/dataset/valid/mathd_algebra_190.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_192.dfy
+++ b/dataset/valid/mathd_algebra_192.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_206.dfy
+++ b/dataset/valid/mathd_algebra_206.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_214.dfy
+++ b/dataset/valid/mathd_algebra_214.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_22.dfy
+++ b/dataset/valid/mathd_algebra_22.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_224.dfy
+++ b/dataset/valid/mathd_algebra_224.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_234.dfy
+++ b/dataset/valid/mathd_algebra_234.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_245.dfy
+++ b/dataset/valid/mathd_algebra_245.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_247.dfy
+++ b/dataset/valid/mathd_algebra_247.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_251.dfy
+++ b/dataset/valid/mathd_algebra_251.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_267.dfy
+++ b/dataset/valid/mathd_algebra_267.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_28.dfy
+++ b/dataset/valid/mathd_algebra_28.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_282.dfy
+++ b/dataset/valid/mathd_algebra_282.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_31.dfy
+++ b/dataset/valid/mathd_algebra_31.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_323.dfy
+++ b/dataset/valid/mathd_algebra_323.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_327.dfy
+++ b/dataset/valid/mathd_algebra_327.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_35.dfy
+++ b/dataset/valid/mathd_algebra_35.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_37.dfy
+++ b/dataset/valid/mathd_algebra_37.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_393.dfy
+++ b/dataset/valid/mathd_algebra_393.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_405.dfy
+++ b/dataset/valid/mathd_algebra_405.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_410.dfy
+++ b/dataset/valid/mathd_algebra_410.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_421.dfy
+++ b/dataset/valid/mathd_algebra_421.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_422.dfy
+++ b/dataset/valid/mathd_algebra_422.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_43.dfy
+++ b/dataset/valid/mathd_algebra_43.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_433.dfy
+++ b/dataset/valid/mathd_algebra_433.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_437.dfy
+++ b/dataset/valid/mathd_algebra_437.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_451.dfy
+++ b/dataset/valid/mathd_algebra_451.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_455.dfy
+++ b/dataset/valid/mathd_algebra_455.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_462.dfy
+++ b/dataset/valid/mathd_algebra_462.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_48.dfy
+++ b/dataset/valid/mathd_algebra_48.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_480.dfy
+++ b/dataset/valid/mathd_algebra_480.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_482.dfy
+++ b/dataset/valid/mathd_algebra_482.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_493.dfy
+++ b/dataset/valid/mathd_algebra_493.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_509.dfy
+++ b/dataset/valid/mathd_algebra_509.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_51.dfy
+++ b/dataset/valid/mathd_algebra_51.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_510.dfy
+++ b/dataset/valid/mathd_algebra_510.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_536.dfy
+++ b/dataset/valid/mathd_algebra_536.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_547.dfy
+++ b/dataset/valid/mathd_algebra_547.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_55.dfy
+++ b/dataset/valid/mathd_algebra_55.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_568.dfy
+++ b/dataset/valid/mathd_algebra_568.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_59.dfy
+++ b/dataset/valid/mathd_algebra_59.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_616.dfy
+++ b/dataset/valid/mathd_algebra_616.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_67.dfy
+++ b/dataset/valid/mathd_algebra_67.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_69.dfy
+++ b/dataset/valid/mathd_algebra_69.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_73.dfy
+++ b/dataset/valid/mathd_algebra_73.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_77.dfy
+++ b/dataset/valid/mathd_algebra_77.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_89.dfy
+++ b/dataset/valid/mathd_algebra_89.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_algebra_96.dfy
+++ b/dataset/valid/mathd_algebra_96.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_101.dfy
+++ b/dataset/valid/mathd_numbertheory_101.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_102.dfy
+++ b/dataset/valid/mathd_numbertheory_102.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_109.dfy
+++ b/dataset/valid/mathd_numbertheory_109.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_110.dfy
+++ b/dataset/valid/mathd_numbertheory_110.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_126.dfy
+++ b/dataset/valid/mathd_numbertheory_126.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_13.dfy
+++ b/dataset/valid/mathd_numbertheory_13.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_132.dfy
+++ b/dataset/valid/mathd_numbertheory_132.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_136.dfy
+++ b/dataset/valid/mathd_numbertheory_136.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_149.dfy
+++ b/dataset/valid/mathd_numbertheory_149.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_155.dfy
+++ b/dataset/valid/mathd_numbertheory_155.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_156.dfy
+++ b/dataset/valid/mathd_numbertheory_156.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_169.dfy
+++ b/dataset/valid/mathd_numbertheory_169.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_188.dfy
+++ b/dataset/valid/mathd_numbertheory_188.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_198.dfy
+++ b/dataset/valid/mathd_numbertheory_198.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_200.dfy
+++ b/dataset/valid/mathd_numbertheory_200.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_202.dfy
+++ b/dataset/valid/mathd_numbertheory_202.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_211.dfy
+++ b/dataset/valid/mathd_numbertheory_211.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_22.dfy
+++ b/dataset/valid/mathd_numbertheory_22.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_221.dfy
+++ b/dataset/valid/mathd_numbertheory_221.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_232.dfy
+++ b/dataset/valid/mathd_numbertheory_232.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_236.dfy
+++ b/dataset/valid/mathd_numbertheory_236.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_24.dfy
+++ b/dataset/valid/mathd_numbertheory_24.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_252.dfy
+++ b/dataset/valid/mathd_numbertheory_252.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_257.dfy
+++ b/dataset/valid/mathd_numbertheory_257.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_269.dfy
+++ b/dataset/valid/mathd_numbertheory_269.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_284.dfy
+++ b/dataset/valid/mathd_numbertheory_284.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_30.dfy
+++ b/dataset/valid/mathd_numbertheory_30.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_301.dfy
+++ b/dataset/valid/mathd_numbertheory_301.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_303.dfy
+++ b/dataset/valid/mathd_numbertheory_303.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_32.dfy
+++ b/dataset/valid/mathd_numbertheory_32.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_326.dfy
+++ b/dataset/valid/mathd_numbertheory_326.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_33.dfy
+++ b/dataset/valid/mathd_numbertheory_33.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_335.dfy
+++ b/dataset/valid/mathd_numbertheory_335.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_35.dfy
+++ b/dataset/valid/mathd_numbertheory_35.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_37.dfy
+++ b/dataset/valid/mathd_numbertheory_37.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_370.dfy
+++ b/dataset/valid/mathd_numbertheory_370.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_403.dfy
+++ b/dataset/valid/mathd_numbertheory_403.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_405.dfy
+++ b/dataset/valid/mathd_numbertheory_405.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_412.dfy
+++ b/dataset/valid/mathd_numbertheory_412.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_42.dfy
+++ b/dataset/valid/mathd_numbertheory_42.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_43.dfy
+++ b/dataset/valid/mathd_numbertheory_43.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_45.dfy
+++ b/dataset/valid/mathd_numbertheory_45.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_458.dfy
+++ b/dataset/valid/mathd_numbertheory_458.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_461.dfy
+++ b/dataset/valid/mathd_numbertheory_461.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_466.dfy
+++ b/dataset/valid/mathd_numbertheory_466.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_48.dfy
+++ b/dataset/valid/mathd_numbertheory_48.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_530.dfy
+++ b/dataset/valid/mathd_numbertheory_530.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_543.dfy
+++ b/dataset/valid/mathd_numbertheory_543.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_629.dfy
+++ b/dataset/valid/mathd_numbertheory_629.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_64.dfy
+++ b/dataset/valid/mathd_numbertheory_64.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_640.dfy
+++ b/dataset/valid/mathd_numbertheory_640.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_668.dfy
+++ b/dataset/valid/mathd_numbertheory_668.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_690.dfy
+++ b/dataset/valid/mathd_numbertheory_690.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_709.dfy
+++ b/dataset/valid/mathd_numbertheory_709.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_739.dfy
+++ b/dataset/valid/mathd_numbertheory_739.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_780.dfy
+++ b/dataset/valid/mathd_numbertheory_780.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_81.dfy
+++ b/dataset/valid/mathd_numbertheory_81.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_84.dfy
+++ b/dataset/valid/mathd_numbertheory_84.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_92.dfy
+++ b/dataset/valid/mathd_numbertheory_92.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/mathd_numbertheory_961.dfy
+++ b/dataset/valid/mathd_numbertheory_961.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/numbertheory_2dvd4expn.dfy
+++ b/dataset/valid/numbertheory_2dvd4expn.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/numbertheory_aneqprodakp4_anmsqrtanp1eq2.dfy
+++ b/dataset/valid/numbertheory_aneqprodakp4_anmsqrtanp1eq2.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/numbertheory_nckeqnm1ckpnm1ckm1.dfy
+++ b/dataset/valid/numbertheory_nckeqnm1ckpnm1ckm1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/numbertheory_prmdvsneqnsqmodpeq0.dfy
+++ b/dataset/valid/numbertheory_prmdvsneqnsqmodpeq0.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/numbertheory_sqmod3in01d.dfy
+++ b/dataset/valid/numbertheory_sqmod3in01d.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/numbertheory_sqmod4in01d.dfy
+++ b/dataset/valid/numbertheory_sqmod4in01d.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/numbertheory_sumkmulnckeqnmul2pownm1.dfy
+++ b/dataset/valid/numbertheory_sumkmulnckeqnmul2pownm1.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 

--- a/dataset/valid/numbertheory_xsqpysqintdenomeq.dfy
+++ b/dataset/valid/numbertheory_xsqpysqintdenomeq.dfy
@@ -1,5 +1,3 @@
-// Author: Stefan Zetzsche
-
 include "../definitions.dfy"
 include "../library.dfy"
 


### PR DESCRIPTION
Removes the trace of the author names in the README.

Removes the `// Author: Stefan Zetzsche` from all Dafny files to anonymize.